### PR TITLE
FIX: App crashes when password is null or tags are retrieved from parcel FIXES #25

### DIFF
--- a/Sealnote/src/main/java/com/twistedplane/sealnote/NoteActivity.java
+++ b/Sealnote/src/main/java/com/twistedplane/sealnote/NoteActivity.java
@@ -108,50 +108,51 @@ public class NoteActivity extends Activity implements ColorDialogFragment.ColorC
         super.onCreate(savedInstanceState);
         setContentView(R.layout.activity_note);
 
-        if(SealnoteApplication.getDatabase().getPassword() == null){
-            startPasswordActivity();
-        }else {
-            // Even though we change content view later, we secure window as soon as possible
-            Misc.secureWindow(NoteActivity.this);
+        if(!Misc.isPasswordLoaded()){
+            Misc.startPasswordActivity(this);
+            return;
+        }
 
-            mBackgroundColor = 0;
-            mAutoSaveEnabled = PreferenceHandler.isAutosaveEnabled(NoteActivity.this);
+        // Even though we change content view later, we secure window as soon as possible
+        Misc.secureWindow(NoteActivity.this);
 
-            int id = -1;
-            int typeInt = -1;
-            Note bundledNote = null;
+        mBackgroundColor = 0;
+        mAutoSaveEnabled = PreferenceHandler.isAutosaveEnabled(NoteActivity.this);
 
-            if (savedInstanceState != null) {
-                id = savedInstanceState.getInt("NOTE_ID", -1);
-                bundledNote = savedInstanceState.getParcelable("NOTE");
-            }
+        int id = -1;
+        int typeInt = -1;
+        Note bundledNote = null;
 
-            if (id == -1) {
-                Bundle extras = getIntent().getExtras();
-                id = extras.getInt("NOTE_ID", -1);
-                typeInt = extras.getInt("NOTE_TYPE", -1);
-            }
+        if (savedInstanceState != null) {
+            id = savedInstanceState.getInt("NOTE_ID", -1);
+            bundledNote = savedInstanceState.getParcelable("NOTE");
+        }
 
-            if (typeInt == -1) {
-                mNoteType = Note.Type.TYPE_GENERIC;
-            } else {
-                mNoteType = Note.Type.values()[typeInt];
-            }
+        if (id == -1) {
+            Bundle extras = getIntent().getExtras();
+            id = extras.getInt("NOTE_ID", -1);
+            typeInt = extras.getInt("NOTE_TYPE", -1);
+        }
 
-            if (id != -1 && savedInstanceState != null && bundledNote != null) {
-                Log.d(TAG, "Unsaved existing note being retrieved from bundle");
-                mLoadingNote = false;
-                init(false, bundledNote.getType());
-                loadNote(bundledNote);
-            } else if (id != -1) {
-                // existing note. Start an async task to load from storage
-                new NoteLoadTask().execute(id);
-            } else {
-                Log.d(TAG, "Creating new note");
-                mLoadingNote = false;
-                init(true, mNoteType); // new note simply setup views
-                getWindow().setSoftInputMode(WindowManager.LayoutParams.SOFT_INPUT_STATE_VISIBLE);
-            }
+        if (typeInt == -1) {
+            mNoteType = Note.Type.TYPE_GENERIC;
+        } else {
+            mNoteType = Note.Type.values()[typeInt];
+        }
+
+        if (id != -1 && savedInstanceState != null && bundledNote != null) {
+            Log.d(TAG, "Unsaved existing note being retrieved from bundle");
+            mLoadingNote = false;
+            init(false, bundledNote.getType());
+            loadNote(bundledNote);
+        } else if (id != -1) {
+            // existing note. Start an async task to load from storage
+            new NoteLoadTask().execute(id);
+        } else {
+            Log.d(TAG, "Creating new note");
+            mLoadingNote = false;
+            init(true, mNoteType); // new note simply setup views
+            getWindow().setSoftInputMode(WindowManager.LayoutParams.SOFT_INPUT_STATE_VISIBLE);
         }
     }
 
@@ -601,11 +602,5 @@ public class NoteActivity extends Activity implements ColorDialogFragment.ColorC
             // will probably be not correct due to delay
             invalidateOptionsMenu();
         }
-    }
-
-    private void startPasswordActivity() {
-        Intent intent = new Intent(this, PasswordActivity.class);
-        startActivity(intent);
-        finish();
     }
 }

--- a/Sealnote/src/main/java/com/twistedplane/sealnote/NoteActivity.java
+++ b/Sealnote/src/main/java/com/twistedplane/sealnote/NoteActivity.java
@@ -107,46 +107,51 @@ public class NoteActivity extends Activity implements ColorDialogFragment.ColorC
     protected void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
         setContentView(R.layout.activity_note);
-        // Even though we change content view later, we secure window as soon as possible
-        Misc.secureWindow(NoteActivity.this);
 
-        mBackgroundColor = 0;
-        mAutoSaveEnabled = PreferenceHandler.isAutosaveEnabled(NoteActivity.this);
+        if(SealnoteApplication.getDatabase().getPassword() == null){
+            startPasswordActivity();
+        }else {
+            // Even though we change content view later, we secure window as soon as possible
+            Misc.secureWindow(NoteActivity.this);
 
-        int id = -1;
-        int typeInt = -1;
-        Note bundledNote = null;
+            mBackgroundColor = 0;
+            mAutoSaveEnabled = PreferenceHandler.isAutosaveEnabled(NoteActivity.this);
 
-        if (savedInstanceState != null) {
-            id = savedInstanceState.getInt("NOTE_ID", -1);
-            bundledNote = savedInstanceState.getParcelable("NOTE");
-        }
+            int id = -1;
+            int typeInt = -1;
+            Note bundledNote = null;
 
-        if (id == -1) {
-            Bundle extras = getIntent().getExtras();
-            id = extras.getInt("NOTE_ID", -1);
-            typeInt = extras.getInt("NOTE_TYPE", -1);
-        }
+            if (savedInstanceState != null) {
+                id = savedInstanceState.getInt("NOTE_ID", -1);
+                bundledNote = savedInstanceState.getParcelable("NOTE");
+            }
 
-        if (typeInt == -1) {
-            mNoteType = Note.Type.TYPE_GENERIC;
-        } else {
-            mNoteType = Note.Type.values()[typeInt];
-        }
+            if (id == -1) {
+                Bundle extras = getIntent().getExtras();
+                id = extras.getInt("NOTE_ID", -1);
+                typeInt = extras.getInt("NOTE_TYPE", -1);
+            }
 
-        if (id != -1 && savedInstanceState != null && bundledNote != null) {
-            Log.d(TAG, "Unsaved existing note being retrieved from bundle");
-            mLoadingNote = false;
-            init(false, bundledNote.getType());
-            loadNote(bundledNote);
-        } else if (id != -1) {
-            // existing note. Start an async task to load from storage
-            new NoteLoadTask().execute(id);
-        } else {
-            Log.d(TAG, "Creating new note");
-            mLoadingNote = false;
-            init(true, mNoteType); // new note simply setup views
-            getWindow().setSoftInputMode(WindowManager.LayoutParams.SOFT_INPUT_STATE_VISIBLE);
+            if (typeInt == -1) {
+                mNoteType = Note.Type.TYPE_GENERIC;
+            } else {
+                mNoteType = Note.Type.values()[typeInt];
+            }
+
+            if (id != -1 && savedInstanceState != null && bundledNote != null) {
+                Log.d(TAG, "Unsaved existing note being retrieved from bundle");
+                mLoadingNote = false;
+                init(false, bundledNote.getType());
+                loadNote(bundledNote);
+            } else if (id != -1) {
+                // existing note. Start an async task to load from storage
+                new NoteLoadTask().execute(id);
+            } else {
+                Log.d(TAG, "Creating new note");
+                mLoadingNote = false;
+                init(true, mNoteType); // new note simply setup views
+                getWindow().setSoftInputMode(WindowManager.LayoutParams.SOFT_INPUT_STATE_VISIBLE);
+            }
         }
     }
 
@@ -596,5 +601,11 @@ public class NoteActivity extends Activity implements ColorDialogFragment.ColorC
             // will probably be not correct due to delay
             invalidateOptionsMenu();
         }
+    }
+
+    private void startPasswordActivity() {
+        Intent intent = new Intent(this, PasswordActivity.class);
+        startActivity(intent);
+        finish();
     }
 }

--- a/Sealnote/src/main/java/com/twistedplane/sealnote/data/Note.java
+++ b/Sealnote/src/main/java/com/twistedplane/sealnote/data/Note.java
@@ -83,7 +83,8 @@ public class Note implements Parcelable{
         mId = inParcel.readInt();
         mPosition = inParcel.readInt();
         mNoteTitle = inParcel.readString();
-        String note = inParcel.readString();
+        mType = Type.valueOf(inParcel.readString());
+        mNote = NoteContent.fromString(mType, inParcel.readString());
         try {
             mEditedDate = EasyDate.fromIsoString(inParcel.readString());
         } catch (ParseException e) {
@@ -92,8 +93,6 @@ public class Note implements Parcelable{
         mColor = inParcel.readInt();
         mArchived = inParcel.readInt() > 0;
         mDeleted = inParcel.readInt() > 0;
-        mType = Type.valueOf(inParcel.readString());
-        mNote = NoteContent.fromString(mType, note);
         mTags = convertToTagSet(inParcel.readString());
     }
 
@@ -102,12 +101,12 @@ public class Note implements Parcelable{
         outParcel.writeInt(mId);
         outParcel.writeInt(mPosition);
         outParcel.writeString(mNoteTitle);
+        outParcel.writeString(mType.name());
         outParcel.writeString(mNote.toString());
         outParcel.writeString(mEditedDate.toString());
         outParcel.writeInt(mColor);
         outParcel.writeInt(mArchived ?1 :0);
         outParcel.writeInt(mDeleted ?1 :0);
-        outParcel.writeString(mType.name());
         outParcel.writeString(convertTagSetToString(mTags));
     }
 

--- a/Sealnote/src/main/java/com/twistedplane/sealnote/data/Note.java
+++ b/Sealnote/src/main/java/com/twistedplane/sealnote/data/Note.java
@@ -93,7 +93,7 @@ public class Note implements Parcelable{
         mArchived = inParcel.readInt() > 0;
         mDeleted = inParcel.readInt() > 0;
         mType = Type.valueOf(inParcel.readString());
-        mNote = NoteContent.fromString(mType, inParcel.readString());
+        mNote = NoteContent.fromString(mType, note);
         mTags = convertToTagSet(inParcel.readString());
     }
 

--- a/Sealnote/src/main/java/com/twistedplane/sealnote/fragment/SealnoteFragment.java
+++ b/Sealnote/src/main/java/com/twistedplane/sealnote/fragment/SealnoteFragment.java
@@ -2,7 +2,6 @@ package com.twistedplane.sealnote.fragment;
 
 import android.app.Fragment;
 import android.app.LoaderManager;
-import android.content.Intent;
 import android.content.Loader;
 import android.database.Cursor;
 import android.database.DataSetObserver;
@@ -16,11 +15,11 @@ import android.view.ViewStub;
 import android.widget.AdapterView;
 import android.widget.TextView;
 import com.twistedplane.sealnote.R;
-import com.twistedplane.sealnote.SealnoteApplication;
 import com.twistedplane.sealnote.data.AdapterLoader;
 import com.twistedplane.sealnote.data.Note;
 import com.twistedplane.sealnote.data.SealnoteAdapter;
-import com.twistedplane.sealnote.PasswordActivity;
+import com.twistedplane.sealnote.utils.Misc;
+
 /**
  * Main fragment where all cards are listed in a staggered grid
  */
@@ -80,39 +79,41 @@ abstract public class SealnoteFragment extends Fragment implements
     public void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
         Log.d(TAG, "Creating SealNote fragment...");
-        if(SealnoteApplication.getDatabase().getPassword()==null){
-            startPasswordActivity();
-        }else {
-            // Get folder active in activity
-            String folder = getArguments().getString("SN_FOLDER", Note.Folder.FOLDER_LIVE.name());
-            int tagid = getArguments().getInt("SN_TAGID", -1);
-            mCurrentFolder = Note.Folder.valueOf(folder);
-            mCurrentTag = tagid;
 
-            mAdapter = createAdapter();
-
-            /**
-             * Called whenever there is change in dataset. Any future changes
-             * will call this
-             */
-            mAdapter.registerDataSetObserver(new DataSetObserver() {
-                @Override
-                public void onChanged() {
-                    super.onChanged();
-                    onAdapterDataSetChanged();
-                }
-
-                @Override
-                public void onInvalidated() {
-                    super.onInvalidated();
-                    Log.d(TAG, "Data set invalidated");
-                    if (isRemoving() || isDetached() || !isVisible()) {
-                        return;
-                    }
-                    setFolder(mCurrentFolder, mCurrentTag);
-                }
-            });
+        if(!Misc.isPasswordLoaded()){
+            Misc.startPasswordActivity(getActivity());
+            return;
         }
+
+        // Get folder active in activity
+        String folder = getArguments().getString("SN_FOLDER", Note.Folder.FOLDER_LIVE.name());
+        int tagid = getArguments().getInt("SN_TAGID", -1);
+        mCurrentFolder = Note.Folder.valueOf(folder);
+        mCurrentTag = tagid;
+
+        mAdapter = createAdapter();
+
+        /**
+         * Called whenever there is change in dataset. Any future changes
+         * will call this
+         */
+        mAdapter.registerDataSetObserver(new DataSetObserver() {
+            @Override
+            public void onChanged() {
+                super.onChanged();
+                onAdapterDataSetChanged();
+            }
+
+            @Override
+            public void onInvalidated() {
+                super.onInvalidated();
+                Log.d(TAG, "Data set invalidated");
+                if (isRemoving() || isDetached() || !isVisible()) {
+                    return;
+                }
+                setFolder(mCurrentFolder, mCurrentTag);
+            }
+        });
     }
 
     /**
@@ -220,10 +221,5 @@ abstract public class SealnoteFragment extends Fragment implements
     public void onLoaderReset(Loader<Cursor> cursorLoader) {
         mAdapter.clearCursor();
         layoutProgressHeader.setVisibility(View.VISIBLE);
-    }
-    private void startPasswordActivity() {
-        Intent intent = new Intent(getActivity(), PasswordActivity.class);
-        startActivity(intent);
-        getActivity().finish();
     }
 }

--- a/Sealnote/src/main/java/com/twistedplane/sealnote/fragment/SealnoteFragment.java
+++ b/Sealnote/src/main/java/com/twistedplane/sealnote/fragment/SealnoteFragment.java
@@ -2,6 +2,7 @@ package com.twistedplane.sealnote.fragment;
 
 import android.app.Fragment;
 import android.app.LoaderManager;
+import android.content.Intent;
 import android.content.Loader;
 import android.database.Cursor;
 import android.database.DataSetObserver;
@@ -15,10 +16,11 @@ import android.view.ViewStub;
 import android.widget.AdapterView;
 import android.widget.TextView;
 import com.twistedplane.sealnote.R;
+import com.twistedplane.sealnote.SealnoteApplication;
 import com.twistedplane.sealnote.data.AdapterLoader;
 import com.twistedplane.sealnote.data.Note;
 import com.twistedplane.sealnote.data.SealnoteAdapter;
-
+import com.twistedplane.sealnote.PasswordActivity;
 /**
  * Main fragment where all cards are listed in a staggered grid
  */
@@ -78,36 +80,39 @@ abstract public class SealnoteFragment extends Fragment implements
     public void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
         Log.d(TAG, "Creating SealNote fragment...");
+        if(SealnoteApplication.getDatabase().getPassword()==null){
+            startPasswordActivity();
+        }else {
+            // Get folder active in activity
+            String folder = getArguments().getString("SN_FOLDER", Note.Folder.FOLDER_LIVE.name());
+            int tagid = getArguments().getInt("SN_TAGID", -1);
+            mCurrentFolder = Note.Folder.valueOf(folder);
+            mCurrentTag = tagid;
 
-        // Get folder active in activity
-        String folder = getArguments().getString("SN_FOLDER", Note.Folder.FOLDER_LIVE.name());
-        int tagid = getArguments().getInt("SN_TAGID", -1);
-        mCurrentFolder = Note.Folder.valueOf(folder);
-        mCurrentTag = tagid;
+            mAdapter = createAdapter();
 
-        mAdapter = createAdapter();
-
-        /**
-         * Called whenever there is change in dataset. Any future changes
-         * will call this
-         */
-        mAdapter.registerDataSetObserver(new DataSetObserver() {
-            @Override
-            public void onChanged() {
-                super.onChanged();
-                onAdapterDataSetChanged();
-            }
-
-            @Override
-            public void onInvalidated() {
-                super.onInvalidated();
-                Log.d(TAG, "Data set invalidated");
-                if (isRemoving() || isDetached() || !isVisible()) {
-                    return;
+            /**
+             * Called whenever there is change in dataset. Any future changes
+             * will call this
+             */
+            mAdapter.registerDataSetObserver(new DataSetObserver() {
+                @Override
+                public void onChanged() {
+                    super.onChanged();
+                    onAdapterDataSetChanged();
                 }
-                setFolder(mCurrentFolder, mCurrentTag);
-            }
-        });
+
+                @Override
+                public void onInvalidated() {
+                    super.onInvalidated();
+                    Log.d(TAG, "Data set invalidated");
+                    if (isRemoving() || isDetached() || !isVisible()) {
+                        return;
+                    }
+                    setFolder(mCurrentFolder, mCurrentTag);
+                }
+            });
+        }
     }
 
     /**
@@ -215,5 +220,10 @@ abstract public class SealnoteFragment extends Fragment implements
     public void onLoaderReset(Loader<Cursor> cursorLoader) {
         mAdapter.clearCursor();
         layoutProgressHeader.setVisibility(View.VISIBLE);
+    }
+    private void startPasswordActivity() {
+        Intent intent = new Intent(getActivity(), PasswordActivity.class);
+        startActivity(intent);
+        getActivity().finish();
     }
 }

--- a/Sealnote/src/main/java/com/twistedplane/sealnote/utils/Misc.java
+++ b/Sealnote/src/main/java/com/twistedplane/sealnote/utils/Misc.java
@@ -2,10 +2,13 @@ package com.twistedplane.sealnote.utils;
 
 import android.app.Activity;
 import android.content.Context;
+import android.content.Intent;
 import android.content.res.Resources;
 import android.view.Window;
 import android.view.WindowManager;
+import com.twistedplane.sealnote.PasswordActivity;
 import com.twistedplane.sealnote.R;
+import com.twistedplane.sealnote.SealnoteApplication;
 
 /**
  * Miscellaneous helper functions
@@ -65,5 +68,15 @@ public class Misc {
         } else {
             window.setFlags(0, WindowManager.LayoutParams.FLAG_SECURE);
         }
+    }
+
+    public static boolean isPasswordLoaded() {
+        return SealnoteApplication.getDatabase().getPassword() != null;
+    }
+
+    public static void startPasswordActivity(Activity activity) {
+        Intent passwordIntent = new Intent(activity, PasswordActivity.class);
+        activity.startActivity(passwordIntent);
+        activity.finish();
     }
 }


### PR DESCRIPTION
- Check for null password and navigate to PasswordActivity if true. When app permissions are revoked manually, the password in the memory is lost and the app crashes.

- Pass note to NoteContent.FromString. Tags are passed to NoteContent instead of note that cause the tags to be null when read from parcel.