### PR TITLE
FIX: App crashes when password is null or tags are retrieved from parcel FIXES #25

### DIFF
--- a/Sealnote/src/main/java/com/twistedplane/sealnote/NoteActivity.java
+++ b/Sealnote/src/main/java/com/twistedplane/sealnote/NoteActivity.java
@@ -107,6 +107,12 @@ public class NoteActivity extends Activity implements ColorDialogFragment.ColorC
     protected void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
         setContentView(R.layout.activity_note);
+
+        if (!Misc.isPasswordLoaded()){
+            Misc.startPasswordActivity(this);
+            return;
+        }
+
         // Even though we change content view later, we secure window as soon as possible
         Misc.secureWindow(NoteActivity.this);
 

--- a/Sealnote/src/main/java/com/twistedplane/sealnote/data/Note.java
+++ b/Sealnote/src/main/java/com/twistedplane/sealnote/data/Note.java
@@ -83,7 +83,8 @@ public class Note implements Parcelable{
         mId = inParcel.readInt();
         mPosition = inParcel.readInt();
         mNoteTitle = inParcel.readString();
-        String note = inParcel.readString();
+        mType = Type.valueOf(inParcel.readString());
+        mNote = NoteContent.fromString(mType, inParcel.readString());
         try {
             mEditedDate = EasyDate.fromIsoString(inParcel.readString());
         } catch (ParseException e) {
@@ -92,8 +93,6 @@ public class Note implements Parcelable{
         mColor = inParcel.readInt();
         mArchived = inParcel.readInt() > 0;
         mDeleted = inParcel.readInt() > 0;
-        mType = Type.valueOf(inParcel.readString());
-        mNote = NoteContent.fromString(mType, inParcel.readString());
         mTags = convertToTagSet(inParcel.readString());
     }
 
@@ -102,12 +101,12 @@ public class Note implements Parcelable{
         outParcel.writeInt(mId);
         outParcel.writeInt(mPosition);
         outParcel.writeString(mNoteTitle);
+        outParcel.writeString(mType.name());
         outParcel.writeString(mNote.toString());
         outParcel.writeString(mEditedDate.toString());
         outParcel.writeInt(mColor);
         outParcel.writeInt(mArchived ?1 :0);
         outParcel.writeInt(mDeleted ?1 :0);
-        outParcel.writeString(mType.name());
         outParcel.writeString(convertTagSetToString(mTags));
     }
 

--- a/Sealnote/src/main/java/com/twistedplane/sealnote/fragment/SealnoteFragment.java
+++ b/Sealnote/src/main/java/com/twistedplane/sealnote/fragment/SealnoteFragment.java
@@ -18,6 +18,7 @@ import com.twistedplane.sealnote.R;
 import com.twistedplane.sealnote.data.AdapterLoader;
 import com.twistedplane.sealnote.data.Note;
 import com.twistedplane.sealnote.data.SealnoteAdapter;
+import com.twistedplane.sealnote.utils.Misc;
 
 /**
  * Main fragment where all cards are listed in a staggered grid
@@ -78,6 +79,11 @@ abstract public class SealnoteFragment extends Fragment implements
     public void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
         Log.d(TAG, "Creating SealNote fragment...");
+
+        if (!Misc.isPasswordLoaded()){
+            Misc.startPasswordActivity(getActivity());
+            return;
+        }
 
         // Get folder active in activity
         String folder = getArguments().getString("SN_FOLDER", Note.Folder.FOLDER_LIVE.name());

--- a/Sealnote/src/main/java/com/twistedplane/sealnote/utils/Misc.java
+++ b/Sealnote/src/main/java/com/twistedplane/sealnote/utils/Misc.java
@@ -2,10 +2,13 @@ package com.twistedplane.sealnote.utils;
 
 import android.app.Activity;
 import android.content.Context;
+import android.content.Intent;
 import android.content.res.Resources;
 import android.view.Window;
 import android.view.WindowManager;
+import com.twistedplane.sealnote.PasswordActivity;
 import com.twistedplane.sealnote.R;
+import com.twistedplane.sealnote.SealnoteApplication;
 
 /**
  * Miscellaneous helper functions
@@ -65,5 +68,15 @@ public class Misc {
         } else {
             window.setFlags(0, WindowManager.LayoutParams.FLAG_SECURE);
         }
+    }
+
+    public static boolean isPasswordLoaded() {
+        return SealnoteApplication.getDatabase().getPassword() != null;
+    }
+
+    public static void startPasswordActivity(Activity activity) {
+        Intent passwordIntent = new Intent(activity, PasswordActivity.class);
+        activity.startActivity(passwordIntent);
+        activity.finish();
     }
 }


### PR DESCRIPTION
- Check for null password and navigate to PasswordActivity if true. When app permissions are
revoked manually, the password in the memory is lost and the app crashes.

- Pass note to NoteContent.FromString. Tags are passed to NoteContent instead of note that cause
the tags to be null when read from parcel.